### PR TITLE
Perf: align hashing policy with runtime roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ $builder = ContainerBuilder::create()
 $path = __DIR__ . '/var/intermix.production.php';
 $report = $builder->compile($path);
 
-// Runtime stage. The digest comes from trusted deployment metadata.
-$container = $builder->productionPrevalidated($path, $report['sha256']);
+// Runtime stage. The xxh128 digest comes from trusted deployment metadata.
+$container = $builder->productionPrevalidated($path, $report['digest']);
 $mailer = $container->get(Mailer::class);
 ```
 
@@ -215,7 +215,8 @@ $signedClosure = $signed->unserialize($signedPayload);
 ```
 
 Ordinary PHP values use native PHP facilities. Resources remain the application's
-responsibility. Signing is instance-scoped and adds no work to normal invocation.
+responsibility. Signed Closure envelopes use HMAC-SHA3-256; signing is instance-scoped
+and adds no work to normal invocation.
 
 ## Testing
 

--- a/benchmarks/DefinitionCacheBench.php
+++ b/benchmarks/DefinitionCacheBench.php
@@ -34,7 +34,7 @@ final class DefinitionCacheBench
         $this->seedHit($this->cacheLayerMemory, '__definition_cache_cachelayer__');
 
         $this->apcu = extension_loaded('apcu') && apcu_enabled()
-            ? Cache::apcu('intermix.benchmark.' . substr(hash('sha256', uniqid('', true)), 0, 12))
+            ? Cache::apcu('intermix.benchmark.' . substr(hash('xxh128', uniqid('', true)), 0, 12))
             : null;
         if ($this->apcu instanceof Cache) {
             $this->seedHit($this->apcu, '__definition_cache_apcu__');

--- a/benchmarks/ProductionRequestPathBench.php
+++ b/benchmarks/ProductionRequestPathBench.php
@@ -230,8 +230,8 @@ final class ProductionRequestPathBench
     {
         static $generator;
         $generator ??= new StaticRuntimeGenerator();
-        [$path, $sha256, $fallback] = $this->bootFixture();
-        $this->sink = $generator->loadPrevalidated($path, $sha256, $fallback);
+        [$path, $digest, $fallback] = $this->bootFixture();
+        $this->sink = $generator->loadPrevalidated($path, $digest, $fallback);
     }
 
     #[Revs(500)]
@@ -293,7 +293,7 @@ final class ProductionRequestPathBench
             }
         });
 
-        return $fixture = [$path, $report['sha256'], $fallback];
+        return $fixture = [$path, $report['digest'], $fallback];
     }
 
     private function controllerRuntime(): ProductionContainer

--- a/docs/di/cheat_sheet.rst
+++ b/docs/di/cheat_sheet.rst
@@ -43,7 +43,7 @@ Container Entry Points
    * - Compile construction recipes
      - ``$c->compileTo($path)`` / ``$c->useCompiled($path)`` / ``$c->compilationReport()``
    * - Finalize a v10 production runtime
-     - ``$builder->compile($path)`` / ``$builder->production($path)`` / ``$builder->productionPrevalidated($path, $sha256)``
+     - ``$builder->compile($path)`` / ``$builder->production($path)`` / ``$builder->productionPrevalidated($path, $digest)``
 
 -----------------------------
 Managers At A Glance

--- a/docs/di/compiled-resolvers.rst
+++ b/docs/di/compiled-resolvers.rst
@@ -42,14 +42,14 @@ the immutable release:
 
    $container = $builder->productionPrevalidated(
        $path,
-       $report['sha256'],
+       $report['digest'],
    );
 
-``production($path)`` verifies the artifact with ``hash_file()`` before loading.
-``productionPrevalidated($path, $sha256)`` is for deployment systems that already
-verified the immutable artifact and obtained its digest from trusted deployment
-metadata. It validates the manifest and expected digest without hashing the PHP
-file on every process start.
+``production($path)`` verifies the artifact with ``hash_file('xxh128', ...)``
+before loading. ``productionPrevalidated($path, $digest)`` is for deployment
+systems that already verified the immutable artifact and obtained its xxh128
+digest from trusted deployment metadata. It validates the manifest and expected
+digest without hashing the PHP file on every process start.
 
 The generated runtime specializes known service IDs, lifetimes, scopes, tags,
 deterministic injection, and known invocation paths. Closures, custom runtime
@@ -208,10 +208,11 @@ artifact for every immutable application release so source-only changes cannot
 reuse an older recipe. Treat the cache file as trusted executable build output
 and never accept its path or contents from a request.
 
-The fingerprints are compatibility coordinates, not authentication. They prove
-that the runtime configuration matches the build input; they do not make an
-untrusted PHP artifact safe to execute. Array definitions that require dynamic
-class or method construction are deliberately omitted and reported as skipped.
+The fingerprints are compatibility coordinates backed by xxh128, not
+authentication. They prove that the runtime configuration matches the build
+input; they do not make an untrusted PHP artifact safe to execute. Array
+definitions that require dynamic class or method construction are deliberately
+omitted and reported as skipped.
 
 When the artifact is loaded before the first service resolution, InterMix uses
 a compiled-first resolver that does not construct the class, parameter, or
@@ -237,7 +238,7 @@ atomic deployment manifest as the artifact, then load both values together:
        $optimizeManifest['container_fingerprint'],
    );
 
-The fingerprint is not a secret. It is an integrity coordinate tying two
+The xxh128 fingerprint is not a secret. It is an integrity coordinate tying two
 trusted deployment outputs together. Never obtain it or the artifact path from
 request input. Rebuild and republish both after definitions, environment,
 container options, PHP, InterMix, providers, or deployment configuration

--- a/docs/di/development-production.rst
+++ b/docs/di/development-production.rst
@@ -111,10 +111,10 @@ Publish all of the following as one release:
 * its adjacent ``.meta.json`` manifest; and
 * application code and dependencies from the same build.
 
-The report's ``sha256`` may also be recorded in trusted immutable deployment
-metadata for prevalidated loading. A database row, cache value, environment
-variable, or file writable by the runtime worker is not automatically a trusted
-digest source.
+The report's ``digest`` is an xxh128 artifact identity and may also be recorded
+in trusted immutable deployment metadata for prevalidated loading. A database
+row, cache value, environment variable, or file writable by the runtime worker
+is not automatically a trusted digest source.
 
 Production bootstrap
 --------------------
@@ -127,7 +127,7 @@ fallback definitions, then load the artifact once during process bootstrap:
    $path = __DIR__ . '/bootstrap/cache/intermix.production.php';
    $builder = applicationContainer('prod');
 
-   // Safe default: validates ABI, manifest, environment and file SHA-256.
+   // Safe default: validates ABI, manifest, environment and file xxh128 digest.
    $container = $builder->production($path);
    $application = $container->get(Application::class);
 
@@ -136,8 +136,8 @@ avoid hashing the file in every new process:
 
 .. code-block:: php
 
-   $trustedSha256 = deploymentMetadata('intermix.sha256');
-   $container = $builder->productionPrevalidated($path, $trustedSha256);
+   $trustedDigest = deploymentMetadata('intermix.digest');
+   $container = $builder->productionPrevalidated($path, $trustedDigest);
 
 ``productionPrevalidated()`` is not a shortcut for reading the digest from the
 same mutable artifact directory. If the trust boundary is uncertain, use
@@ -187,7 +187,7 @@ callables:
    $report = $productionBuilder->compile($temporaryPath);
    $production = $productionBuilder->productionPrevalidated(
        $temporaryPath,
-       $report['sha256'],
+       $report['digest'],
    );
 
    expect($production->get(Application::class))

--- a/docs/di/quickstart.rst
+++ b/docs/di/quickstart.rst
@@ -186,17 +186,17 @@ bootstrap:
    // Build/deploy step:
    $report = $builder->compile(__DIR__ . '/bootstrap/cache/intermix.php');
 
-   // Runtime bootstrap; persist $report['sha256'] as trusted deployment metadata.
+   // Runtime bootstrap; persist the xxh128 digest as trusted deployment metadata.
    $runtime = $builder->productionPrevalidated(
        __DIR__ . '/bootstrap/cache/intermix.php',
-       $report['sha256'],
+       $report['digest'],
    );
 
    $app = $runtime->get(App::class);
 
-The normal ``production()`` loader hashes and validates the artifact on boot.
-``productionPrevalidated()`` skips that file hash only when its digest came
-from trusted immutable deployment metadata. Never compile during a live
+The normal ``production()`` loader hashes and validates the artifact on boot with
+xxh128. ``productionPrevalidated()`` skips that file hash only when its digest
+came from trusted immutable deployment metadata. Never compile during a live
 request. See :doc:`compiled-resolvers` for dynamic-island and deployment rules.
 For complete side-by-side bootstraps and the reasons behind each choice, read
 :doc:`development-production`.

--- a/docs/intermix-10-performance-architecture.md
+++ b/docs/intermix-10-performance-architecture.md
@@ -58,7 +58,7 @@ This checker is authoritative for the InterMix 10 standalone implementation.
 - [x] 23. Keep Closure definitions and `DirectFactory` as explicit dynamic islands with compiled-ID bridges preserving singleton/scoped identity across compiled↔dynamic edges.
 - [x] 24. Implement explicit production deoptimization for configuration mutation with original definitions restored and compiled singleton/scoped identity transferred; repeated loads replace fallback bridges safely and post-finalization mutation through the builder, a retained manager, or the development container requires recompilation.
 - [x] 25. Separate compiler/diagnostic metadata into a sidecar; the hot artifact contains generated runtime execution code only.
-- [x] 26. Perform atomic generation and build/deployment validation with ABI/SHA-256 and compiled-environment metadata; prevalidated production loading avoids request-time `hash_file()` work.
+- [x] 26. Perform atomic generation and build/deployment validation with ABI/xxh128 digest and compiled-environment metadata; prevalidated production loading avoids request-time `hash_file()` work.
 - [x] 27. Finalize the constant-folding/transient-inlining decision: no additional speculative inlining pass is added without stable representative evidence of a sustained end-to-end win.
 - [x] 28. Benchmark generated boundary representations. The immutable ID→slot candidate showed only a noisy nominal advantage, so the simpler generated string `match` boundary is retained until stable-environment measurements justify changing it.
 - [x] 29. Keep Repository/managers/reflection resolver machinery entirely out of fully static generated artifacts; instantiate the optimized dynamic engine lazily only when a declared compatibility island is exercised.
@@ -180,7 +180,7 @@ Production loading:
 ```php
 $container = $builder->productionPrevalidated(
     '/cache/intermix.prod.php',
-    $report['sha256'],
+    $report['digest'],
 );
 ```
 
@@ -435,7 +435,7 @@ Arbitrary parameterized runtime callables preserve development error and resolut
 
 Production compilation is explicit and atomic.
 
-The compiler emits the runtime artifact plus metadata/manifest information containing ABI and digest data.
+The compiler emits the runtime artifact plus metadata/manifest information containing ABI and xxh128 digest data.
 
 Build/deployment validates:
 
@@ -454,7 +454,7 @@ Production never performs expensive compilation because an artifact is absent on
 
 ## 26. Prevalidated loading
 
-Normal verified loading can validate an artifact digest.
+Normal verified loading validates the artifact with its xxh128 digest.
 
 Deployment systems that already validated the artifact may use prevalidated loading with the expected digest, eliminating request-time `hash_file()` work.
 
@@ -472,7 +472,7 @@ The sidecar may contain:
 - environment metadata
 - compiler report
 - source/debug information
-- artifact ABI and digest
+- artifact ABI and xxh128 digest
 
 Tooling/debugging can load it on demand without burdening normal request bootstrap.
 

--- a/docs/serializer.rst
+++ b/docs/serializer.rst
@@ -50,7 +50,7 @@ provide equivalent integrity protection.
    $payload = $serializer->serialize(static fn (): string => 'work');
    $closure = $serializer->unserialize($payload);
 
-Signed payloads use the ``imxcs1.`` envelope and HMAC-SHA-256. Signing keys are
+Signed payloads use the ``imxcs2.`` envelope and HMAC-SHA3-256. Signing keys are
 held by the serializer instance; InterMix has no process-global signing state.
 Unsigned serializers reject signed payloads, signed serializers reject unsigned
 payloads, and verification occurs before executable data is decoded.

--- a/src/DI/Build/StaticRuntimeGenerator.php
+++ b/src/DI/Build/StaticRuntimeGenerator.php
@@ -94,6 +94,15 @@ final class StaticRuntimeGenerator
         return $this->attachFallback($this->loadRuntime($filePath), $fallback);
     }
 
+    private function assertDigest(string $digest): void
+    {
+        if (preg_match('/^[a-f0-9]{32}$/D', $digest) !== 1) {
+            throw new ContainerException(
+                'Prevalidated static runtime digest must be a lowercase xxh128 hexadecimal value.',
+            );
+        }
+    }
+
     /** @param array{abi: int, digest: string, environment: ?string} $manifest */
     private function assertEnvironmentMatches(array $manifest, ?Container $fallback): void
     {
@@ -115,15 +124,6 @@ final class StaticRuntimeGenerator
         if ($manifest['abi'] !== self::ARTIFACT_ABI) {
             throw new ContainerException(
                 "Unsupported static runtime ABI '{$manifest['abi']}'.",
-            );
-        }
-    }
-
-    private function assertDigest(string $digest): void
-    {
-        if (preg_match('/^[a-f0-9]{32}$/D', $digest) !== 1) {
-            throw new ContainerException(
-                'Prevalidated static runtime digest must be a lowercase xxh128 hexadecimal value.',
             );
         }
     }

--- a/src/DI/Build/StaticRuntimeGenerator.php
+++ b/src/DI/Build/StaticRuntimeGenerator.php
@@ -22,7 +22,7 @@ final class StaticRuntimeGenerator
      *   runtime: ProductionContainer,
      *   compiled: list<string>,
      *   skipped: array<string, string>,
-     *   sha256: string
+     *   digest: string
      * }
      */
     public function generate(
@@ -38,7 +38,7 @@ final class StaticRuntimeGenerator
         }
 
         $source = new StaticRuntimeRenderer()->render($graph, $plans, $slots);
-        $sha256 = hash('sha256', $source);
+        $digest = hash('xxh128', $source);
         AtomicFileWriter::write(
             $filePath,
             $source,
@@ -48,17 +48,17 @@ final class StaticRuntimeGenerator
         );
         $this->writeManifest(
             $filePath,
-            $sha256,
+            $digest,
             array_keys($plans),
             $planned['skipped'],
             $graph->environment(),
         );
 
         return [
-            'runtime' => $this->loadPrevalidated($filePath, $sha256, $fallback),
+            'runtime' => $this->loadPrevalidated($filePath, $digest, $fallback),
             'compiled' => array_keys($plans),
             'skipped' => $planned['skipped'],
-            'sha256' => $sha256,
+            'digest' => $digest,
         ];
     }
 
@@ -71,20 +71,20 @@ final class StaticRuntimeGenerator
     }
 
     /**
-     * Load an artifact whose SHA-256 digest was validated during deployment.
+     * Load an artifact whose xxh128 digest was validated during deployment.
      *
      * This deliberately does not hash the runtime file. The caller must source
      * the digest from trusted immutable deployment metadata.
      */
     public function loadPrevalidated(
         string $filePath,
-        string $expectedSha256,
+        string $expectedDigest,
         ?Container $fallback = null,
     ): ProductionContainer {
-        $this->assertSha256($expectedSha256);
+        $this->assertDigest($expectedDigest);
         $manifest = $this->readManifest($filePath);
         $this->assertManifestAbi($manifest);
-        if (!hash_equals($manifest['sha256'], $expectedSha256)) {
+        if (!hash_equals($manifest['digest'], $expectedDigest)) {
             throw new ContainerException(
                 'Prevalidated static runtime does not match the active deployment digest.',
             );
@@ -94,7 +94,7 @@ final class StaticRuntimeGenerator
         return $this->attachFallback($this->loadRuntime($filePath), $fallback);
     }
 
-    /** @param array{abi: int, sha256: string, environment: ?string} $manifest */
+    /** @param array{abi: int, digest: string, environment: ?string} $manifest */
     private function assertEnvironmentMatches(array $manifest, ?Container $fallback): void
     {
         if (!$fallback instanceof Container) {
@@ -109,7 +109,7 @@ final class StaticRuntimeGenerator
         }
     }
 
-    /** @param array{abi: int, sha256: string, environment: ?string} $manifest */
+    /** @param array{abi: int, digest: string, environment: ?string} $manifest */
     private function assertManifestAbi(array $manifest): void
     {
         if ($manifest['abi'] !== self::ARTIFACT_ABI) {
@@ -119,11 +119,11 @@ final class StaticRuntimeGenerator
         }
     }
 
-    private function assertSha256(string $sha256): void
+    private function assertDigest(string $digest): void
     {
-        if (preg_match('/^[a-f0-9]{64}$/D', $sha256) !== 1) {
+        if (preg_match('/^[a-f0-9]{32}$/D', $digest) !== 1) {
             throw new ContainerException(
-                'Prevalidated static runtime digest must be a SHA-256 hexadecimal value.',
+                'Prevalidated static runtime digest must be a lowercase xxh128 hexadecimal value.',
             );
         }
     }
@@ -156,7 +156,7 @@ final class StaticRuntimeGenerator
         return $filePath . self::MANIFEST_SUFFIX;
     }
 
-    /** @return array{abi: int, sha256: string, environment: ?string} */
+    /** @return array{abi: int, digest: string, environment: ?string} */
     private function readManifest(string $filePath): array
     {
         $manifestPath = $this->manifestPath($filePath);
@@ -175,10 +175,11 @@ final class StaticRuntimeGenerator
             throw new ContainerException('Static runtime manifest is invalid JSON.', previous: $exception);
         }
         if (!is_array($manifest)
-            || !isset($manifest['abi'], $manifest['sha256'])
+            || !isset($manifest['abi'], $manifest['digest'])
             || !array_key_exists('environment', $manifest)
             || !is_int($manifest['abi'])
-            || !is_string($manifest['sha256'])
+            || !is_string($manifest['digest'])
+            || preg_match('/^[a-f0-9]{32}$/D', $manifest['digest']) !== 1
             || (!is_string($manifest['environment']) && $manifest['environment'] !== null)
         ) {
             throw new ContainerException('Static runtime manifest has an invalid shape.');
@@ -186,19 +187,19 @@ final class StaticRuntimeGenerator
 
         return [
             'abi' => $manifest['abi'],
-            'sha256' => $manifest['sha256'],
+            'digest' => $manifest['digest'],
             'environment' => $manifest['environment'],
         ];
     }
 
-    /** @return array{abi: int, sha256: string, environment: ?string} */
+    /** @return array{abi: int, digest: string, environment: ?string} */
     private function validateManifest(string $filePath): array
     {
         $manifest = $this->readManifest($filePath);
         $this->assertManifestAbi($manifest);
 
-        $hash = hash_file('sha256', $filePath);
-        if (!is_string($hash) || !hash_equals($manifest['sha256'], $hash)) {
+        $hash = hash_file('xxh128', $filePath);
+        if (!is_string($hash) || !hash_equals($manifest['digest'], $hash)) {
             throw new ContainerException('Static runtime artifact hash does not match its manifest.');
         }
 
@@ -211,7 +212,7 @@ final class StaticRuntimeGenerator
      */
     private function writeManifest(
         string $filePath,
-        string $sha256,
+        string $digest,
         array $compiled,
         array $skipped,
         ?string $environment,
@@ -220,7 +221,7 @@ final class StaticRuntimeGenerator
             $manifest = json_encode(
                 [
                     'abi' => self::ARTIFACT_ABI,
-                    'sha256' => $sha256,
+                    'digest' => $digest,
                     'environment' => $environment,
                     'compiled' => $compiled,
                     'skipped' => $skipped,

--- a/src/DI/ContainerBuilder.php
+++ b/src/DI/ContainerBuilder.php
@@ -20,7 +20,7 @@ final class ContainerBuilder
 {
     private readonly Container $development;
 
-    /** @var null|array{compiled: list<string>, skipped: array<string, string>, sha256: string} */
+    /** @var null|array{compiled: list<string>, skipped: array<string, string>, digest: string} */
     private ?array $compilationReport = null;
 
     /** @var array<string, true> */
@@ -96,13 +96,13 @@ final class ContainerBuilder
         return $this;
     }
 
-    /** @return null|array{compiled: list<string>, skipped: array<string, string>, sha256: string} */
+    /** @return null|array{compiled: list<string>, skipped: array<string, string>, digest: string} */
     public function compilationReport(): ?array
     {
         return $this->compilationReport;
     }
 
-    /** @return array{compiled: list<string>, skipped: array<string, string>, sha256: string} */
+    /** @return array{compiled: list<string>, skipped: array<string, string>, digest: string} */
     public function compile(string $path): array
     {
         $this->beforeMutation();
@@ -119,7 +119,7 @@ final class ContainerBuilder
         $this->compilationReport = [
             'compiled' => $generated['compiled'],
             'skipped' => $generated['skipped'],
-            'sha256' => $generated['sha256'],
+            'digest' => $generated['digest'],
         ];
         $this->finalizedArtifactExists = true;
         $this->requiresCompilation = false;
@@ -209,7 +209,7 @@ final class ContainerBuilder
         );
     }
 
-    public function productionPrevalidated(string $path, string $sha256): ProductionContainer
+    public function productionPrevalidated(string $path, string $digest): ProductionContainer
     {
         $this->beforeProductionLoad();
 
@@ -217,7 +217,7 @@ final class ContainerBuilder
             fn(): ProductionContainer => $this->rememberProductionRuntime(
                 new StaticRuntimeGenerator()->loadPrevalidated(
                     $path,
-                    $sha256,
+                    $digest,
                     $this->development,
                 ),
             ),

--- a/src/DI/Resolver/Repository.php
+++ b/src/DI/Resolver/Repository.php
@@ -670,10 +670,10 @@ class Repository
     public function makeDefinitionCacheKey(string $definition): string
     {
         $this->definitionCachePrefix ??= 'imx.'
-            . substr(hash('sha256', $this->alias), 0, 16)
+            . substr(hash('xxh128', $this->alias), 0, 16)
             . '.' . substr(
                 hash(
-                    'sha256',
+                    'xxh128',
                     ($this->definitionCacheGeneration ?? 'default') . "\0" . $this->definitionCacheRevision,
                 ),
                 0,
@@ -682,7 +682,7 @@ class Repository
             . '.';
 
         return $this->definitionCachePrefix
-            . substr(hash('sha256', $definition . "\0" . ($this->environment ?? 'default')), 0, 16);
+            . substr(hash('xxh128', $definition . "\0" . ($this->environment ?? 'default')), 0, 16);
     }
 
     /** @internal */

--- a/src/DI/Support/CompiledResolverGenerator.php
+++ b/src/DI/Support/CompiledResolverGenerator.php
@@ -103,14 +103,14 @@ final class CompiledResolverGenerator
      * runtime, fingerprint, and callable payload before activation.
      *
      * @param string $filePath Trusted compiled artifact path.
-     * @param string $expectedFingerprint Deployment-validated SHA-256 fingerprint.
+     * @param string $expectedFingerprint Deployment-validated xxh128 fingerprint.
      * @return array{resolver: Closure(Container, string): mixed, ids: array<string, string>}
      * @throws ContainerException
      */
     public function loadPrevalidated(string $filePath, string $expectedFingerprint): array
     {
-        if (preg_match('/^[a-f0-9]{64}$/D', $expectedFingerprint) !== 1) {
-            throw new ContainerException('Prevalidated resolver fingerprint must be a SHA-256 hexadecimal digest.');
+        if (preg_match('/^[a-f0-9]{32}$/D', $expectedFingerprint) !== 1) {
+            throw new ContainerException('Prevalidated resolver fingerprint must be a lowercase xxh128 hexadecimal digest.');
         }
         if (!is_file($filePath) || !is_readable($filePath)) {
             throw new ContainerException("Compiled resolver artifact is not readable: '$filePath'.");
@@ -146,7 +146,7 @@ final class CompiledResolverGenerator
      */
     private static function stableHash(array $value): string
     {
-        return hash('sha256', serialize($value));
+        return hash('xxh128', serialize($value));
     }
 
     /**

--- a/src/Remix/MacroMix.php
+++ b/src/Remix/MacroMix.php
@@ -237,7 +237,7 @@ trait MacroMix
             throw new RuntimeException('Unable to create the InterMix lock directory.');
         }
         chmod($directory, 0700);
-        $path = $directory . '/macro-' . hash('sha256', static::class) . '.lock';
+        $path = $directory . '/macro-' . hash('xxh128', static::class) . '.lock';
         $handle = fopen($path, 'c');
         if ($handle === false) {
             throw new RuntimeException('Unable to open the MacroMix mutation lock.');

--- a/src/Serializer/SignedClosureSerializer.php
+++ b/src/Serializer/SignedClosureSerializer.php
@@ -13,9 +13,9 @@ use function Opis\Closure\{serialize as opis_serialize, unserialize as opis_unse
 
 final readonly class SignedClosureSerializer
 {
-    private const string HMAC_ALGORITHM = 'sha256';
+    private const string HMAC_ALGORITHM = 'sha3-256';
 
-    private const string PREFIX = 'imxcs1.';
+    private const string PREFIX = 'imxcs2.';
 
     public function __construct(
         #[\SensitiveParameter]

--- a/tests/Container/CompiledResolverTest.php
+++ b/tests/Container/CompiledResolverTest.php
@@ -499,7 +499,7 @@ it('loads a deployment-prevalidated artifact and rejects a mismatched manifest f
     $rejected->bind('service', CompiledResolverDependency::class, LifetimeEnum::Transient);
 
     expect($runtime->get('service'))->toBeInstanceOf(CompiledResolverDependency::class)
-        ->and(fn() => $rejected->usePrevalidated($path, str_repeat('0', 64)))
+        ->and(fn() => $rejected->usePrevalidated($path, str_repeat('0', 32)))
         ->toThrow(ContainerException::class)
         ->and($rejected->getRepository()->getCompiledResolver('service'))->toBeNull()
         ->and(fn() => $rejected->usePrevalidated($path, 'invalid'))
@@ -508,7 +508,7 @@ it('loads a deployment-prevalidated artifact and rejects a mismatched manifest f
 
 it('rejects malformed service IDs in a prevalidated artifact', function () {
     $path = compiledResolverPath();
-    $fingerprint = str_repeat('a', 64);
+    $fingerprint = str_repeat('a', 32);
     $php = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
     file_put_contents($path, <<<PHP
         <?php

--- a/tests/Container/ProductionContainerTest.php
+++ b/tests/Container/ProductionContainerTest.php
@@ -145,7 +145,7 @@ it('deoptimizes a prior production runtime before attaching another to the build
     try {
         $report = $builder->compile($path);
         $first = $builder->production($path);
-        $second = $builder->productionPrevalidated($path, $report['sha256']);
+        $second = $builder->productionPrevalidated($path, $report['digest']);
         $development = $builder->development();
 
         expect($first)->not->toBe($second)

--- a/tests/Container/StaticAttributeClassificationTest.php
+++ b/tests/Container/StaticAttributeClassificationTest.php
@@ -94,7 +94,7 @@ it('does not deoptimize methods for unregistered parameter attributes', function
 
     try {
         $report = $builder->compile($path);
-        $consumer = $builder->productionPrevalidated($path, $report['sha256'])->get('consumer');
+        $consumer = $builder->productionPrevalidated($path, $report['digest'])->get('consumer');
 
         expect($report['compiled'])->toContain('consumer', StaticAttributeDependency::class)
             ->and($consumer->dependency)->toBeInstanceOf(StaticAttributeDependency::class);
@@ -116,7 +116,7 @@ it('keeps registered custom method attribute resolvers as targeted runtime islan
     try {
         $report = $builder->compile($path);
         $source = file_get_contents($path);
-        $consumer = $builder->productionPrevalidated($path, $report['sha256'])->get('consumer');
+        $consumer = $builder->productionPrevalidated($path, $report['digest'])->get('consumer');
 
         expect($report['compiled'])->toContain('consumer')
             ->and($source)->toContain('invokeCompiledRuntimeMethod')
@@ -140,7 +140,7 @@ it('preserves development semantics by ignoring method attributes on constructor
         expect($builder->development()->get('consumer')->value)->toBe('fallback');
 
         $report = $builder->compile($path);
-        $consumer = $builder->productionPrevalidated($path, $report['sha256'])->get('consumer');
+        $consumer = $builder->productionPrevalidated($path, $report['digest'])->get('consumer');
 
         expect($report['compiled'])->toContain('consumer')
             ->and($consumer->value)->toBe('fallback');
@@ -162,7 +162,7 @@ it('keeps registered custom property attribute resolvers as targeted runtime isl
     try {
         $report = $builder->compile($path);
         $source = file_get_contents($path);
-        $consumer = $builder->productionPrevalidated($path, $report['sha256'])->get('consumer');
+        $consumer = $builder->productionPrevalidated($path, $report['digest'])->get('consumer');
 
         expect($report['compiled'])->toContain('consumer')
             ->and($source)->toContain('applyCompiledRuntimePropertyAttribute')

--- a/tests/Container/StaticBuiltInInjectCompilationTest.php
+++ b/tests/Container/StaticBuiltInInjectCompilationTest.php
@@ -71,7 +71,7 @@ it('compiles deterministic method-level Inject arguments without changing litera
 
     try {
         $report = $builder->compile($path);
-        $consumer = $builder->productionPrevalidated($path, $report['sha256'])->get('consumer');
+        $consumer = $builder->productionPrevalidated($path, $report['digest'])->get('consumer');
 
         expect($report['compiled'])->toContain('consumer', 'config.message')
             ->and($consumer)->toBeInstanceOf(StaticMethodLevelInjectConsumer::class)
@@ -91,7 +91,7 @@ it('compiles deterministic parameter-level Inject service targets', function () 
 
     try {
         $report = $builder->compile($path);
-        $consumer = $builder->productionPrevalidated($path, $report['sha256'])->get('consumer');
+        $consumer = $builder->productionPrevalidated($path, $report['digest'])->get('consumer');
 
         expect($report['compiled'])->toContain('consumer', 'config.message')
             ->and($consumer)->toBeInstanceOf(StaticParameterLevelInjectConsumer::class)
@@ -111,7 +111,7 @@ it('keeps typed method-level Inject precedence as a targeted runtime method isla
     try {
         $report = $builder->compile($path);
         $source = file_get_contents($path);
-        $consumer = $builder->productionPrevalidated($path, $report['sha256'])->get('consumer');
+        $consumer = $builder->productionPrevalidated($path, $report['digest'])->get('consumer');
 
         expect($report['compiled'])->toContain('consumer')
             ->and($source)->toContain('invokeCompiledRuntimeMethod')

--- a/tests/Container/StaticGenericModeTest.php
+++ b/tests/Container/StaticGenericModeTest.php
@@ -57,7 +57,7 @@ it('compiles zero-required-argument generic classes without autowiring machinery
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
         $first = $runtime->get('empty');
         $second = $runtime->get('empty');
         $optional = $runtime->get('optional');
@@ -81,7 +81,7 @@ it('keeps registered generic constructor behavior in the dynamic island', functi
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
         $configured = $runtime->get('configured');
 
         expect($report['compiled'])->not->toContain('configured')
@@ -102,7 +102,7 @@ it('keeps DI-style class recipes dynamic when injection is disabled', function (
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
 
         expect($report['compiled'])->toContain('answer')
             ->and($report['compiled'])->not->toContain('consumer')

--- a/tests/Container/StaticGetReturnParityTest.php
+++ b/tests/Container/StaticGetReturnParityTest.php
@@ -76,7 +76,7 @@ it('preserves registered getReturn semantics while still invoking configured met
     $path = staticGetReturnArtifactPath();
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
         $runtime->enterScope('request');
         $productionSingleton = $runtime->getReturn('singleton');
         $productionScoped = $runtime->getReturn('scoped');

--- a/tests/Container/StaticLifecycleHookCompilationTest.php
+++ b/tests/Container/StaticLifecycleHookCompilationTest.php
@@ -46,7 +46,7 @@ it('keeps hooked singleton services compiled and dispatches hooks only on cache 
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
 
         $first = $runtime->get('service');
         $second = $runtime->get('service');
@@ -72,7 +72,7 @@ it('captures hooks registered through a retained development container', functio
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
 
         expect($runtime->get('service'))->toBeInstanceOf(StaticHookCompiledService::class)
             ->and($events)->toBe(['service']);
@@ -95,7 +95,7 @@ it('dispatches compiled transient value hooks for every resolution', function ()
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
 
         expect($runtime->get('answer'))->toBe(42)
             ->and($runtime->get('answer'))->toBe(42)
@@ -127,7 +127,7 @@ it('preserves scoped hook and scope-leave semantics in production', function () 
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
 
         $runtime->enterScope('request');
         $first = $runtime->get('service');
@@ -164,7 +164,7 @@ it('dispatches lifecycle hooks around compiled invocation results', function () 
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
 
         expect($runtime->get('invocation'))->toBe('invoked')
             ->and($runtime->get('invocation'))->toBe('invoked')
@@ -184,7 +184,7 @@ it('fails closed when a hooked artifact is loaded without its runtime hook graph
 
     try {
         $report = $builder->compile($path);
-        $runtime = new StaticRuntimeGenerator()->loadPrevalidated($path, $report['sha256']);
+        $runtime = new StaticRuntimeGenerator()->loadPrevalidated($path, $report['digest']);
 
         expect(fn() => $runtime->get('service'))
             ->toThrow(ContainerException::class, 'runtime lifecycle-hook graph');

--- a/tests/Container/StaticPrevalidatedRuntimeTest.php
+++ b/tests/Container/StaticPrevalidatedRuntimeTest.php
@@ -28,9 +28,9 @@ it('loads a production runtime from the deployment digest returned by compile', 
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
 
-        expect($report['sha256'])->toMatch('/^[a-f0-9]{64}$/')
+        expect($report['digest'])->toMatch('/^[a-f0-9]{32}$/')
             ->and($runtime->get('service'))->toBeInstanceOf(StaticPrevalidatedService::class)
             ->and($runtime->get('service'))->toBe($runtime->get('service'));
     } finally {
@@ -47,10 +47,10 @@ it('rejects malformed and mismatched deployment digests', function () {
         $report = $builder->compile($path);
 
         expect(fn() => $builder->productionPrevalidated($path, 'invalid'))
-            ->toThrow(ContainerException::class, 'SHA-256')
-            ->and(fn() => $builder->productionPrevalidated($path, str_repeat('0', 64)))
+            ->toThrow(ContainerException::class, 'xxh128')
+            ->and(fn() => $builder->productionPrevalidated($path, str_repeat('0', 32)))
             ->toThrow(ContainerException::class, 'deployment digest')
-            ->and($report['sha256'])->not->toBe(str_repeat('0', 64));
+            ->and($report['digest'])->not->toBe(str_repeat('0', 32));
     } finally {
         removeStaticPrevalidatedArtifact($path);
     }
@@ -68,7 +68,7 @@ it('requires recompilation after environment mutation', function () {
 
         expect(fn() => $builder->production($path))
             ->toThrow(ContainerException::class, 'recompiled')
-            ->and(fn() => $builder->productionPrevalidated($path, $report['sha256']))
+            ->and(fn() => $builder->productionPrevalidated($path, $report['digest']))
             ->toThrow(ContainerException::class, 'recompiled');
     } finally {
         removeStaticPrevalidatedArtifact($path);
@@ -89,7 +89,7 @@ it('validates the artifact environment when loading in a fresh process builder',
 
         expect(fn() => $loader->production($path))
             ->toThrow(ContainerException::class, 'environment')
-            ->and(fn() => $loader->productionPrevalidated($path, $report['sha256']))
+            ->and(fn() => $loader->productionPrevalidated($path, $report['digest']))
             ->toThrow(ContainerException::class, 'environment');
     } finally {
         removeStaticPrevalidatedArtifact($path);

--- a/tests/Container/StaticPropertyInjectFastPathTest.php
+++ b/tests/Container/StaticPropertyInjectFastPathTest.php
@@ -54,7 +54,7 @@ it('keeps compile-known private Inject dependencies out of attribute resolution 
     try {
         $report = $builder->compile($path);
         $source = file_get_contents($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
         $dependency = $runtime->get(StaticPrivateInjectDependency::class);
         $private = $runtime->get(StaticPrivateInjectConsumer::class);
         $readonly = $runtime->get(StaticReadonlyInjectConsumer::class);

--- a/tests/Container/StaticRuntimeFinalParityTest.php
+++ b/tests/Container/StaticRuntimeFinalParityTest.php
@@ -52,7 +52,7 @@ it('preserves compiled call error semantics for missing methods', function () {
 
     try {
         $report = $productionBuilder->compile($path);
-        $runtime = $productionBuilder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $productionBuilder->productionPrevalidated($path, $report['digest']);
 
         expect($developmentError)->toBeInstanceOf(ContainerException::class)
             ->and(fn() => $runtime->call('callable', 'missing'))->toThrow(
@@ -71,7 +71,7 @@ it('keeps arbitrary closure invocation in a narrow dynamic island with compiled 
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
         $consumer = $runtime->resolveNow(
             static fn(StaticFinalParityDependency $dependency): StaticFinalParityRoot => new StaticFinalParityRoot($dependency),
         );
@@ -99,7 +99,7 @@ it('preserves callable parser errors across development and production fallback'
 
     try {
         $report = $productionBuilder->compile($path);
-        $runtime = $productionBuilder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $productionBuilder->productionPrevalidated($path, $report['digest']);
 
         expect($developmentError)->toBeInstanceOf(ContainerException::class)
             ->and(fn() => $runtime->resolveNow(['StaticFinalParityMissingClass', 'run']))->toThrow(
@@ -127,7 +127,7 @@ it('preserves malformed array callable errors without production warnings', func
 
     try {
         $report = $builder->compile($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
 
         expect($developmentError)->toBeInstanceOf(InvalidArgumentException::class)
             ->and(fn() => $runtime->resolveNow([]))->toThrow(

--- a/tests/Container/StaticRuntimePropertyIslandTest.php
+++ b/tests/Container/StaticRuntimePropertyIslandTest.php
@@ -38,7 +38,7 @@ it('keeps non-exportable registered property values in a targeted runtime island
     try {
         $report = $builder->compile($path);
         $source = file_get_contents($path);
-        $runtime = $builder->productionPrevalidated($path, $report['sha256']);
+        $runtime = $builder->productionPrevalidated($path, $report['digest']);
         $consumer = $runtime->get(RuntimePropertyIslandConsumer::class);
 
         expect($report['compiled'])->toContain(RuntimePropertyIslandConsumer::class)

--- a/tests/Integration/CacheLayerIntegrationTest.php
+++ b/tests/Integration/CacheLayerIntegrationTest.php
@@ -270,7 +270,7 @@ it('integrates with CacheLayer APCu when available', function () {
         test()->markTestSkipped('APCu is not enabled.');
     }
 
-    $cache = Cache::apcu('intermix.apcu.' . substr(hash('sha256', uniqid('', true)), 0, 12));
+    $cache = Cache::apcu('intermix.apcu.' . substr(hash('xxh128', uniqid('', true)), 0, 12));
     $container = cacheLayerContainer(uniqid('apcu.', true));
     $container->definitions()->enableDefinitionCache($cache);
     $container->bind('value', static fn(): int => 42);

--- a/tests/Remix/MacroMixTest.php
+++ b/tests/Remix/MacroMixTest.php
@@ -164,7 +164,7 @@ it('releases the mutation lock when an operation throws', function () {
     expect(fn() => $mutate->invoke(null, static fn() => throw new RuntimeException('failed')))
         ->toThrow(RuntimeException::class, 'failed');
 
-    $path = sys_get_temp_dir() . '/intermix-locks/macro-' . hash('sha256', MacroTestClass::class) . '.lock';
+    $path = sys_get_temp_dir() . '/intermix-locks/macro-' . hash('xxh128', MacroTestClass::class) . '.lock';
     $handle = fopen($path, 'c');
     if ($handle === false) {
         throw new RuntimeException('Unable to open test lock.');
@@ -177,7 +177,7 @@ it('releases the mutation lock when an operation throws', function () {
 
 it('keeps reads and macro execution lock-free', function () {
     MacroTestClass::macro('lockFreeRead', static fn(): string => 'read');
-    $path = sys_get_temp_dir() . '/intermix-locks/macro-' . hash('sha256', MacroTestClass::class) . '.lock';
+    $path = sys_get_temp_dir() . '/intermix-locks/macro-' . hash('xxh128', MacroTestClass::class) . '.lock';
     $handle = fopen($path, 'c');
     if ($handle === false) {
         throw new RuntimeException('Unable to open test lock.');

--- a/tests/Serializer/ClosureSerializerTest.php
+++ b/tests/Serializer/ClosureSerializerTest.php
@@ -30,7 +30,7 @@ it('recognizes only the unsigned InterMix envelope', function () {
     expect($payload)->toStartWith('imxc1.')
         ->and(ClosureSerializer::isEnvelope($payload))->toBeTrue()
         ->and(ClosureSerializer::isEnvelope('not-a-payload'))->toBeFalse()
-        ->and(ClosureSerializer::isEnvelope('imxcs1.signature.payload'))->toBeFalse();
+        ->and(ClosureSerializer::isEnvelope('imxcs2.signature.payload'))->toBeFalse();
 });
 
 it('rejects missing malformed and non-Closure payloads', function (string $payload) {
@@ -48,7 +48,7 @@ it('round-trips a signed Closure', function () {
     $payload = $serializer->serialize(static fn(int $value): int => $value * 2);
     $closure = $serializer->unserialize($payload);
 
-    expect($payload)->toStartWith('imxcs1.')
+    expect($payload)->toStartWith('imxcs2.')
         ->and($closure(6))->toBe(12);
 });
 


### PR DESCRIPTION
## Summary

Fully align InterMix hashing with a role-based policy:

- `xxh128` for non-security artifact identities, runtime fingerprints, cache identities, lock identities, and deployment digests.
- `sha3-256` for mandatory cryptographic signing/HMAC.
- Generic `digest` naming instead of algorithm-specific `sha256` API fields.

## Completed changes

- Static production runtime artifact digest: `sha256` -> `xxh128`.
- `ContainerBuilder::compile()` report key: `sha256` -> `digest`.
- `ContainerBuilder::productionPrevalidated()` accepts a generic `digest`.
- Static runtime manifest key: `sha256` -> `digest`.
- Normal static-runtime verification uses `hash_file('xxh128', ...)`.
- Prevalidated runtime digest validation uses a 32-character lowercase xxh128 digest.
- Compiled resolver fingerprints and prevalidated fingerprints use `xxh128`.
- Definition-cache identities use `xxh128`.
- MacroMix lock identities use `xxh128`.
- Cache/benchmark namespace identities use `xxh128`.
- Signed Closure HMAC uses `sha3-256`.
- Signed Closure envelope version is `imxcs2` to make the crypto-format change explicit.
- Tests, benchmarks, README, and DI/serializer/performance documentation migrated to the new contracts.
- Remaining 64-character SHA-256-style test fixtures migrated to 32-character xxh128 fingerprints.

## Hashing policy

| Role | Algorithm |
| --- | --- |
| Local artifact digest / deployment identity | `xxh128` |
| Resolver/configuration fingerprint | `xxh128` |
| Cache key / namespace identity | `xxh128` |
| Lock filename identity | `xxh128` |
| Cryptographic signing / HMAC | `sha3-256` |

No SHA-256 compatibility shim is retained.

## Validation

`Security & Standards` workflow run #419 is green on the final head:

- PHP 8.4 QA: stable + prefer-lowest ✅
- PHP 8.5 QA: stable + prefer-lowest ✅
- PHPStan/Psalm PHP 8.4 ✅
- PHPStan/Psalm PHP 8.5 ✅
- Clean production install/autoload/platform checks ✅

The PHPForge benchmark job is not enabled by this workflow run and was skipped by workflow configuration, not by a benchmark failure.

## Cross-repo follow-up

Webrick PR #44 can now consume InterMix `digest` instead of the old `intermix.sha256` manifest field.