### PR TITLE
Fix intrinsic ContainerInterface in generated runtimes

### DIFF
--- a/src/DI/Build/StaticRuntimePlanner.php
+++ b/src/DI/Build/StaticRuntimePlanner.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Infocyph\InterMix\DI\Build;
 
+use Infocyph\InterMix\DI\Container;
 use Infocyph\InterMix\DI\Support\AliasDefinition;
 use Infocyph\InterMix\DI\Support\FactoryDefinition;
 use Infocyph\InterMix\DI\Support\LifetimeEnum;
 use Infocyph\InterMix\Internal\ReflectionResource;
+use Psr\Container\ContainerInterface;
 use ReflectionClass;
 
 /**
@@ -409,6 +411,16 @@ final class StaticRuntimePlanner
     /** @return ValuePlan|null */
     private function valuePlan(DefinitionGraph $graph, string $id, mixed $definition): ?array
     {
+        if ($id === ContainerInterface::class && $definition instanceof Container) {
+            return [
+                'kind' => 'value',
+                'code' => '$this',
+                'lifetime' => LifetimeEnum::Singleton,
+                'arguments' => [],
+                'properties' => [],
+                'dependencies' => [],
+            ];
+        }
         if (!$this->isExportable($definition) || (is_array($definition) && $this->isCallableArrayDefinition($definition))) {
             return null;
         }

--- a/tests/Container/StaticRuntimeContainerInterfaceTest.php
+++ b/tests/Container/StaticRuntimeContainerInterfaceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Infocyph\InterMix\DI\ContainerBuilder;
+use Psr\Container\ContainerInterface;
+
+final readonly class StaticRuntimeContainerInterfaceConsumer
+{
+    public function __construct(public ContainerInterface $container) {}
+}
+
+final class StaticRuntimeUserContainer implements ContainerInterface
+{
+    public function get(string $id): mixed
+    {
+        throw new RuntimeException("Unknown service: {$id}");
+    }
+
+    public function has(string $id): bool
+    {
+        return false;
+    }
+}
+
+function staticRuntimeContainerInterfaceArtifactPath(): string
+{
+    return sys_get_temp_dir() . '/intermix-container-interface-' . bin2hex(random_bytes(8)) . '.php';
+}
+
+function removeStaticRuntimeContainerInterfaceArtifact(string $path): void
+{
+    foreach ([$path, $path . '.meta.json'] as $artifact) {
+        if (is_file($artifact)) {
+            unlink($artifact);
+        }
+    }
+}
+
+it('compiles the intrinsic container interface as the generated production container', function () {
+    $builder = ContainerBuilder::create(uniqid('container_interface_'))
+        ->singleton(StaticRuntimeContainerInterfaceConsumer::class);
+    $path = staticRuntimeContainerInterfaceArtifactPath();
+
+    try {
+        $report = $builder->compile($path);
+        $runtime = $builder->production($path);
+        $consumer = $runtime->get(StaticRuntimeContainerInterfaceConsumer::class);
+
+        expect($report['skipped'])->toBe([])
+            ->and($report['compiled'])->toContain(
+                ContainerInterface::class,
+                StaticRuntimeContainerInterfaceConsumer::class,
+            )
+            ->and($runtime->get(ContainerInterface::class))->toBe($runtime)
+            ->and($consumer)->toBeInstanceOf(StaticRuntimeContainerInterfaceConsumer::class)
+            ->and($consumer->container)->toBe($runtime);
+    } finally {
+        removeStaticRuntimeContainerInterfaceArtifact($path);
+    }
+});
+
+it('does not treat a user-rebound container interface as the intrinsic container', function () {
+    $container = new StaticRuntimeUserContainer();
+    $builder = ContainerBuilder::create(uniqid('user_container_interface_'))
+        ->value(ContainerInterface::class, $container);
+    $path = staticRuntimeContainerInterfaceArtifactPath();
+
+    try {
+        $report = $builder->compile($path);
+        $runtime = $builder->production($path);
+
+        expect($report['skipped'])->toHaveKey(ContainerInterface::class)
+            ->and($runtime->get(ContainerInterface::class))->toBe($container);
+    } finally {
+        removeStaticRuntimeContainerInterfaceArtifact($path);
+    }
+});


### PR DESCRIPTION
## Summary

Fix static production-runtime planning for InterMix's intrinsic `Psr\Container\ContainerInterface` binding.

A development `Repository` seeds `ContainerInterface::class` with the live mutable `Container`. The static planner previously treated that object value as dynamic, so the intrinsic binding was skipped and every statically planned service depending on `ContainerInterface` was pruned from the generated runtime.

## Fix

When—and only when—the definition is the intrinsic InterMix development `Container` stored under `ContainerInterface::class`, emit a static value plan whose generated expression is `$this` and whose lifetime is singleton.

That makes the production contract consistent:

- `ProductionContainer::get(ContainerInterface::class)` returns the generated production container itself.
- Constructor-injected `ContainerInterface` receives that same production container.
- Dependent services remain statically compilable instead of being pruned.
- A user-rebound `ContainerInterface` definition is not special-cased and continues through the normal dynamic/static planning rules.

## Regression coverage

Adds focused production-runtime tests proving:

- the compile report has no skipped definitions for a consumer that depends on `ContainerInterface`;
- both the direct intrinsic lookup and constructor injection resolve to the same generated `ProductionContainer`;
- an explicitly user-rebound `ContainerInterface` object remains the user value rather than being replaced with the generated runtime.

## Why this is needed

Foundation's generated CLI/worker/scheduler graphs legitimately inject the PSR container into runtime services. InterMix 10.0.3 currently prunes those services because the intrinsic development container value cannot be exported. This patch fixes that lower-layer ownership issue without requiring a Foundation proxy or service-locator workaround.